### PR TITLE
Deal with metadata error from Tesla result

### DIFF
--- a/lib/spandex_tesla.ex
+++ b/lib/spandex_tesla.ex
@@ -26,7 +26,12 @@ defmodule SpandexTesla do
     end
   end
 
-  def handle_event([:tesla, :request, :stop], measurements, %{error: error, env: env} = metadata, config) do
+  def handle_event(
+        [:tesla, :request, :stop],
+        measurements,
+        %{error: error, env: env} = metadata,
+        config
+      ) do
     now = clock_adapter().system_time()
     %{duration: duration} = measurements
     %{url: url, method: method} = env

--- a/lib/spandex_tesla.ex
+++ b/lib/spandex_tesla.ex
@@ -26,6 +26,27 @@ defmodule SpandexTesla do
     end
   end
 
+  def handle_event([:tesla, :request, :stop], measurements, %{error: error, env: env} = metadata, config) do
+    now = clock_adapter().system_time()
+    %{duration: duration} = measurements
+    %{url: url, method: method} = env
+
+    trace_opts =
+      format_trace_options(
+        %{duration: duration, status: nil, method: method, now: now, url: url},
+        metadata,
+        config || []
+      )
+
+    tracer().span_error(
+      %Error{message: error},
+      nil,
+      trace_opts
+    )
+
+    tracer().finish_span([])
+  end
+
   def handle_event([:tesla, :request, :stop], measurements, metadata, config) do
     if tracer().current_trace_id([]) do
       now = clock_adapter().system_time()


### PR DESCRIPTION
## Motivation

We are currently not dealing with errors that are not exceptions from Tesla, for example, the timeout error.
Take a look at how Tesla sent these errors [here](https://github.com/teamon/tesla/blob/c1e0f2d031eb87a207db33333b8d4afc58384e87/lib/tesla/middleware/telemetry.ex#L121) 
And take a look that the timeout error is not sent as an exception [here](https://github.com/teamon/tesla/blob/c1e0f2d031eb87a207db33333b8d4afc58384e87/lib/tesla/middleware/timeout.ex#L38), so we are never sending the timeouts as errors to datadog

## Proposed solution
I propose a new approach, just dealing when we receive some error on result metadata of the event :stop, and sending this error as span_error.

Please take a look
