### PR TITLE
[HOTFIX] Span error convert atom to string

### DIFF
--- a/lib/spandex_tesla.ex
+++ b/lib/spandex_tesla.ex
@@ -44,7 +44,7 @@ defmodule SpandexTesla do
       )
 
     tracer().span_error(
-      %Error{message: error},
+      %Error{message: Atom.to_string(error)},
       nil,
       trace_opts
     )

--- a/test/spandex_tesla_test.exs
+++ b/test/spandex_tesla_test.exs
@@ -178,7 +178,7 @@ defmodule SpandexTeslaTest do
       |> expect(:current_span_id, fn [] -> span_id end)
       |> expect(:start_span, fn "request", [] -> nil end)
       |> expect(:span_error, fn error, nil, opts ->
-        assert error == %SpandexTesla.Error{message: :timeout}
+        assert error == %SpandexTesla.Error{message: "timeout"}
         assert opts[:start] == now - duration
         assert opts[:completion_time] == now
         assert opts[:service] == :tesla


### PR DESCRIPTION
## Motivation

We receive the error as an Atom, and we need to convert this to a string to send the span error

## Proposed solution

Convert the atom to string before sending the span error
