### PR TITLE
Tesla error can be any term

### DIFF
--- a/lib/spandex_tesla.ex
+++ b/lib/spandex_tesla.ex
@@ -43,15 +43,8 @@ defmodule SpandexTesla do
         config || []
       )
 
-    message =
-      case error do
-        err when is_binary(err) -> err
-        err when is_atom(err) -> to_string(err)
-        err -> inspect(err)
-      end
-
     tracer().span_error(
-      %Error{message: message},
+      %Error{message: span_error_message(error)},
       nil,
       trace_opts
     )
@@ -181,6 +174,10 @@ defmodule SpandexTesla do
 
     "#{upcased_method} #{resource_url}"
   end
+
+  defp span_error_message(error) when is_binary(error), do: error
+  defp span_error_message(error) when is_atom(error), do: to_string(error)
+  defp span_error_message(error), do: inspect(error)
 
   defp tracer do
     Application.fetch_env!(:spandex_tesla, :tracer)

--- a/lib/spandex_tesla.ex
+++ b/lib/spandex_tesla.ex
@@ -43,8 +43,15 @@ defmodule SpandexTesla do
         config || []
       )
 
+    message =
+      case error do
+        err when is_binary(err) -> err
+        err when is_atom(err) -> to_string(err)
+        err -> inspect(err)
+      end
+
     tracer().span_error(
-      %Error{message: Atom.to_string(error)},
+      %Error{message: message},
       nil,
       trace_opts
     )

--- a/test/spandex_tesla_test.exs
+++ b/test/spandex_tesla_test.exs
@@ -165,57 +165,65 @@ defmodule SpandexTeslaTest do
     end
 
     test "span tesla request with error on result metadata" do
-      now = System.system_time()
-      duration = 1_000
-      trace_id = "trace_id"
-      span_id = "span_id"
+      errors = [
+        {"timeout", "timeout"},
+        {:timeout, "timeout"},
+        {%{reason: :timeout}, "%{reason: :timeout}"}
+      ]
 
-      ClockMock
-      |> expect(:system_time, fn -> now end)
+      for {tesla_error, expected_message} <- errors do
+        now = System.system_time()
+        duration = 1_000
+        trace_id = "trace_id"
+        span_id = "span_id"
 
-      TracerMock
-      |> expect(:current_trace_id, 2, fn [] -> trace_id end)
-      |> expect(:current_span_id, fn [] -> span_id end)
-      |> expect(:start_span, fn "request", [] -> nil end)
-      |> expect(:span_error, fn error, nil, opts ->
-        assert error == %SpandexTesla.Error{message: "timeout"}
-        assert opts[:start] == now - duration
-        assert opts[:completion_time] == now
-        assert opts[:service] == :tesla
-        assert opts[:resource] == "GET https://google.com/item/:item_id"
-        assert opts[:type] == :web
+        ClockMock
+        |> expect(:system_time, fn -> now end)
 
-        assert opts[:http] == [
-                 url: "https://google.com/item/555",
-                 status_code: nil,
-                 method: "GET"
-               ]
-      end)
-      |> expect(:finish_span, fn [] -> nil end)
+        TracerMock
+        |> expect(:current_trace_id, 2, fn [] -> trace_id end)
+        |> expect(:current_span_id, fn [] -> span_id end)
+        |> expect(:start_span, fn "request", [] -> nil end)
+        |> expect(:span_error, fn error, nil, opts ->
+          assert error == %SpandexTesla.Error{message: expected_message}
+          assert opts[:start] == now - duration
+          assert opts[:completion_time] == now
+          assert opts[:service] == :tesla
+          assert opts[:resource] == "GET https://google.com/item/:item_id"
+          assert opts[:type] == :web
 
-      SpandexTesla.handle_event(
-        [:tesla, :request, :start],
-        nil,
-        nil,
-        resource: &resource_name/1
-      )
+          assert opts[:http] == [
+                   url: "https://google.com/item/555",
+                   status_code: nil,
+                   method: "GET"
+                 ]
+        end)
+        |> expect(:finish_span, fn [] -> nil end)
 
-      SpandexTesla.handle_event(
-        [:tesla, :request, :stop],
-        %{duration: duration},
-        %{
-          env: %{
-            url: "https://google.com/item/555",
-            method: :get,
-            status: nil,
-            opts: []
+        SpandexTesla.handle_event(
+          [:tesla, :request, :start],
+          nil,
+          nil,
+          resource: &resource_name/1
+        )
+
+        SpandexTesla.handle_event(
+          [:tesla, :request, :stop],
+          %{duration: duration},
+          %{
+            env: %{
+              url: "https://google.com/item/555",
+              method: :get,
+              status: nil,
+              opts: []
+            },
+            error: tesla_error
           },
-          error: :timeout
-        },
-        resource: &resource_name/1
-      )
+          resource: &resource_name/1
+        )
 
-      assert Logger.metadata() == [span_id: "span_id", trace_id: "trace_id"]
+        assert Logger.metadata() == [span_id: "span_id", trace_id: "trace_id"]
+      end
     end
 
     test "span tesla request with status code different from 2xx should sent error to spandex" do


### PR DESCRIPTION
## Motivation

A Tesla [result](https://hexdocs.pm/tesla/Tesla.Env.html#t:result/0) error value has the type `any()`.  I suspect the actual type is largely dependent on the adapter being used.  For example I'm seeing `%Mint.TransportError{reason: :timeout}` when using Mint.

edit: I guess more specifically, the [telemetry](https://hexdocs.pm/tesla/Tesla.Middleware.Telemetry.html#module-telemetry-events) metadata structure type indicates `error: term()`

`Atom.to_string/1` raises when the Tesla error is anything but an atom, causing the telemetry handler to detach.

## Proposed solution

Set the span error message to a reasonable string interpretation of the error.